### PR TITLE
Use the FIPSDIR env var and always build the latest version

### DIFF
--- a/openssl-fips/plan.sh
+++ b/openssl-fips/plan.sh
@@ -1,12 +1,14 @@
 pkg_name=openssl-fips
 pkg_description="The OpenSSL FIPS module"
 pkg_origin=socrata
-pkg_version="2.0.16"
+pkg_version=$(wget -q -O - https://www.openssl.org/source/ | \
+              grep -E -o '>openssl-fips-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz<' | \
+              sed -E 's/^>openssl-fips-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz<$/\1/')
 pkg_maintainer="Socrata Engineering <sysadmin@socrata.com>"
 pkg_license=('OpenSSL')
 pkg_upstream_url="https://www.openssl.org"
 pkg_source="https://www.openssl.org/source/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="a3cd13d0521d22dd939063d3b4a0d4ce24494374b91408a05bdaca8b681c63d4"
+pkg_shasum=$(wget -q -O - ${pkg_source}.sha256)
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
@@ -16,16 +18,7 @@ pkg_deps=(core/glibc)
 pkg_build_deps=(core/coreutils core/gcc core/make core/perl)
 
 do_build() {
+  export FIPSDIR=$pkg_prefix
   ./config
   make
-}
-
-do_install() {
-  do_default_install
-
-  src=/usr/local/ssl/fips-2.0  
-  for dir in bin include lib; do
-    mv $src/$dir $pkg_prefix/
-  done
-  rmdir $src
 }

--- a/openssl-fips/plan.sh
+++ b/openssl-fips/plan.sh
@@ -22,3 +22,10 @@ do_build() {
   ./config
   make
 }
+
+do_install() {
+  do_default_install
+  # Do this after the install to be on the safe side of satisfying "you cannot
+  # modify the contents of the official tarball".
+  sed -i 's,/bin/rm,rm,g' ${pkg_prefix}/bin/fipsld
+}


### PR DESCRIPTION
Would this really be that much worse than eyeballing things and updating the
version and SHA manually? Someone malicious either gaining control of
www.openssl.org and/or a valid SSL certificate for it would be just as much a
problem for a human as for a build script.