### PR TITLE
Set the OpenSSL versions and SHAs explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 */results/
+results/

--- a/openssl-fips/NOTICE
+++ b/openssl-fips/NOTICE
@@ -3,8 +3,8 @@ OpenSSL-FIPS Habitat Plan Notice
 
 This plan is developed by [Socrata](https://socrata.com).
 
-Maintainers
------------
+Contributors
+------------
 
 * Jonathan Hartman <jonathan.hartman@socrata.com>
 

--- a/openssl-fips/plan.sh
+++ b/openssl-fips/plan.sh
@@ -1,14 +1,12 @@
 pkg_name=openssl-fips
 pkg_description="The OpenSSL FIPS module"
 pkg_origin=socrata
-pkg_version=$(wget -q -O - https://www.openssl.org/source/ | \
-              grep -E -o '>openssl-fips-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz<' | \
-              sed -E 's/^>openssl-fips-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz<$/\1/')
+pkg_version=2.0.16
 pkg_maintainer="Socrata Engineering <sysadmin@socrata.com>"
 pkg_license=('OpenSSL')
 pkg_upstream_url="https://www.openssl.org"
 pkg_source="https://www.openssl.org/source/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=$(wget -q -O - ${pkg_source}.sha256)
+pkg_shasum=a3cd13d0521d22dd939063d3b4a0d4ce24494374b91408a05bdaca8b681c63d4
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)

--- a/openssl/NOTICE
+++ b/openssl/NOTICE
@@ -3,8 +3,8 @@ OpenSSL Habitat Plan Notice
 
 This plan is developed by [Socrata](https://socrata.com).
 
-Maintainers
------------
+Contributors
+------------
 
 * Jonathan Hartman <jonathan.hartman@socrata.com>
 

--- a/openssl/plan.sh
+++ b/openssl/plan.sh
@@ -1,14 +1,12 @@
 pkg_name=openssl
 pkg_description="The OpenSSL cryptography and SSL/TLS toolkit in FIPS mode"
 pkg_origin=socrata
-pkg_version=$(wget -q -O - https://www.openssl.org/source/ | \
-              grep -E -o '>openssl-1\.0\.[0-9]+[a-z]\.tar\.gz<' | \
-              sed -E 's/^>openssl-(1\.0\.[0-9]+[a-z])\.tar\.gz<$/\1/')
+pkg_version=1.0.2m
 pkg_maintainer="Socrata Engineering <sysadmin@socrata.com>"
 pkg_license=('OpenSSL')
 pkg_upstream_url="https://www.openssl.org"
 pkg_source="https://www.openssl.org/source/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=$(wget -q -O - ${pkg_source}.sha256)
+pkg_shasum=8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Artifacts should be reproducible. We'll find another way to update versions
rapidly.