### PR TITLE
[inspec] Fix the failing integration test

### DIFF
--- a/inspec/test/integration/app_test.rb
+++ b/inspec/test/integration/app_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 pkg_origin = ENV['HAB_ORIGIN']
-pkg_path = command("hab pkg path #{pkg_origin}/inspec").stdout
+pkg_path = command("hab pkg path #{pkg_origin}/inspec").stdout.strip
 
 describe command("#{pkg_path}/bin/inspec --help") do
   its(:exit_status) { should eq(0) }


### PR DESCRIPTION
The newline needs to be stripped off the end of the package path.