### PR TITLE
[carbon] Fix the failing integration test

### DIFF
--- a/carbon/test/integration/default/app_test.rb
+++ b/carbon/test/integration/default/app_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 pkg_origin = ENV['HAB_ORIGIN']
-pkg_path = command("hab pkg path #{pkg_origin}/carbon").stdout
+pkg_path = command("hab pkg path #{pkg_origin}/carbon").stdout.strip
 pip_path = File.join(pkg_path, 'bin/pip')
 
 describe directory('/opt/graphite') do


### PR DESCRIPTION
The newline needs to be stripped off the end of the package path.