### PR TITLE
[carbon-cache] Fix the failing integration tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,8 @@ driver:
   name: docker
   use_sudo: false
   provision_command:
+    - apt-get update
+    - apt-get -y install iproute2 net-tools
     - mkdir -p /run/sshd
   volume:
     - <%= File.expand_path('~/.hab/cache') %>:/hab/cache

--- a/carbon-cache/hooks/post-run
+++ b/carbon-cache/hooks/post-run
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+for n in $(seq 1 10); do
+  {{pkg.svc_path}}/hooks/health_check > /dev/null
+  [ $? = 0 ] && exit 0
+  echo "Waiting for service to come up..."
+  sleep 1
+done
+
+exit 1

--- a/carbon-cache/plan.sh
+++ b/carbon-cache/plan.sh
@@ -23,7 +23,7 @@ pkg_exposes=(
 
 # The package version is whatever version of Carbon we're building on top of.
 pkg_version() {
-  < "$(pkg_path_for "${pkg_origin}/carbon")/IDENT" cut -d '/' -f 3
+  < "$(pkg_path_for socrata/carbon)/IDENT" cut -d '/' -f 3
 }
 
 do_before() {

--- a/carbon-cache/test/integration/app_test.rb
+++ b/carbon-cache/test/integration/app_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'spec_helper'
+
 describe directory('/opt/graphite') do
   it { should_not exist }
 end

--- a/carbon-cache/test/integration/config_test.rb
+++ b/carbon-cache/test/integration/config_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'spec_helper'
+
 conf = '/hab/svc/carbon-cache/config'
 
 describe file(File.join(conf, 'carbon.conf')) do
@@ -10,15 +12,17 @@ describe file(File.join(conf, 'carbon.conf')) do
       WHITELISTS_DIR = /hab/svc/carbon-cache/data/lists
       CONF_DIR = /hab/svc/carbon-cache/config
       PID_DIR = /hab/svc/carbon-cache/var
-      MAX_UPDATES_PER_SECOND = 100
-      MAX_CREATES_PER_MINUTE = 200
-      LINE_RECEIVER_PORT = 2003
-      UDP_RECEIVER_PORT = 2003
-      PICKLE_RECEIVER_PORT = 2004
-      ENABLE_UDP_LISTENER = True
       CACHE_QUERY_PORT = 7002
-      LOG_UPDATES = False
+      ENABLE_UDP_LISTENER = True
+      LINE_RECEIVER_PORT = 2003
       LOG_CACHE_HITS = False
+      LOG_UPDATES = False
+      MAX_CREATES_PER_MINUTE = 200
+      MAX_UPDATES_PER_SECOND = 100
+      PICKLE_RECEIVER_PORT = 2004
+      STORAGE_DIR = /hab/svc/carbon-cache/data
+      UDP_RECEIVER_PORT = 2003
+
     EXP
     should eq(expected)
   end
@@ -28,12 +32,13 @@ describe file(File.join(conf, 'storage-schemas.conf')) do
   its(:content) do
     expected = <<-EXP.gsub(/^ +/, '')
       [500_carbon]
-      PATTERN = ^carbon\.
+      PATTERN = ^carbon\\.
       RETENTIONS = 60s:90d
-
       [999_default_1min_for_1day]
       PATTERN = .*
       RETENTIONS = 60s:1d,5m:14d,1h:365d
-    end
+
+    EXP
+    should eq(expected)
   end
 end

--- a/carbon-cache/test/integration/spec_helper.rb
+++ b/carbon-cache/test/integration/spec_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'timeout'
+
+RSpec.configure do |c|
+  c.before do
+    Timeout::timeout(30) do
+      url = 'http://127.0.0.1:9631/services/carbon-cache/default'
+
+      while http(url).status != 200 || \
+            JSON.parse(http(url).body)['process']['state'] != 'up'
+        sleep(1)
+      end
+    end
+  end
+end

--- a/test/check-bad-patterns.sh
+++ b/test/check-bad-patterns.sh
@@ -48,8 +48,9 @@ file_check() {
       continue
     fi
 
-    # It's OK to block in the run hook, but nowhere else.
-    if [[ ${1##*/} != "run" && $line == *"sleep"* ]]; then
+    # It's OK to block in the run hook and bad-but-sometimes-necessary in
+    # post-run, but nowhere else.
+    if [[ ${1##*/} != "run" && ${1##*/} != "post-run" && $line == *"sleep"* ]]; then
       sleeps=$((sleeps + 1))
       continue
     fi


### PR DESCRIPTION
Optimally, we shouldn't sleep in a post-run hook, but it takes a few seconds
for the cache to be fully started and there isn't really a better option until
Habitat adds a new lifecycle hook or a setting to not consider a service
started until its health check hook is passing.