### PR TITLE
[carbon] Convert from kitchen-habitat to kitchen-dokken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ bin/*
 .kitchen.local.yml
 */.kitchen.local.yml
 
+# Berkshelf
+Berksfile.lock
+
 # TravisCI
 .travis/*
 !.travis/configs.tar.gz.enc

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,17 +1,16 @@
 ---
 driver:
-  name: docker
-  use_sudo: false
-  provision_command:
-    - apt-get update
-    - apt-get -y install iproute2 net-tools
-    - mkdir -p /run/sshd
-  volume:
+  name: dokken
+  privileged: true
+  volumes:
     - <%= File.expand_path('~/.hab/cache') %>:/hab/cache
+    - <%= File.expand_path(__dir__) %>:/tmp/habitat-plans
+
+transport:
+  name: dokken
 
 provisioner:
-  name: habitat
-  install_latest_artifact: true
+  name: dokken
 
 verifier:
   name: inspec
@@ -20,9 +19,20 @@ verifier:
 
 platforms:
   - name: ubuntu
+    driver:
+      intermediate_instructions:
+        - RUN apt-get update
+        - RUN apt-get -y install systemd iproute2
+      pid_one_command: /lib/systemd/systemd
 
 suites:
   - name: <%= ENV['HAB_ORIGIN'] || raise('Environment variable HAB_ORIGIN must be set') %>-<%= ENV['HAB_PLAN'] || raise('Environment variable HAB_PLAN must be set') %>
     provisioner:
       package_origin: <%= ENV['HAB_ORIGIN'] %>
       package_name: <%= ENV['HAB_PLAN'] %>
+    run_list:
+      - recipe[plan_test]
+    attributes:
+      hab:
+        origin: <%= ENV['HAB_ORIGIN'] %>
+        plan: <%= ENV['HAB_PLAN'] %>

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://supermarket.chef.io'
+
+cookbook 'hab_test', path: 'test/fixtures/cookbooks/hab_test'
+cookbook 'plan_test',
+         path: "#{ENV['HAB_PLAN']}/test/fixtures/cookbooks/plan_test"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'kitchen-docker'
-gem 'kitchen-habitat'

--- a/carbon/test/fixtures/cookbooks/plan_test/metadata.rb
+++ b/carbon/test/fixtures/cookbooks/plan_test/metadata.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+name 'plan_test'
+maintainer 'Tyler Technologies, Data & Insights Division'
+maintainer_email 'sysadmin@socrata.com'
+license 'Apache-2.0'
+description 'Test wrapper'
+long_description 'Test wrapper'
+version '0.0.1'
+
+depends 'hab_test'

--- a/carbon/test/fixtures/cookbooks/plan_test/recipes/default.rb
+++ b/carbon/test/fixtures/cookbooks/plan_test/recipes/default.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+include_recipe 'hab_test'

--- a/test/fixtures/cookbooks/hab_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/hab_test/attributes/default.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+default['hab']['origin'] = nil
+default['hab']['plan'] = nil

--- a/test/fixtures/cookbooks/hab_test/metadata.rb
+++ b/test/fixtures/cookbooks/hab_test/metadata.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+name 'hab_test'
+maintainer 'Tyler Technologies, Data & Insights Division'
+maintainer_email 'sysadmin@socrata.com'
+license 'Apache-2.0'
+description 'Test wrapper'
+long_description 'Test wrapper'
+version '0.0.1'
+
+depends 'habitat'

--- a/test/fixtures/cookbooks/hab_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/hab_test/recipes/default.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+origin = node['hab']['origin']
+plan = node['hab']['plan']
+
+apt_update 'default'
+package 'curl'
+# package %w[iproute2 net-tools]
+# directory '/run/sshd'
+
+hab_install 'default'
+hab_sup 'default'
+
+execute "Generate a stub signing key for #{origin}" do
+  command "hab origin key generate #{origin}"
+  not_if "hab origin key export #{origin}"
+end
+
+execute "Build #{origin}/#{plan}" do
+  command "hab pkg build #{plan}"
+  cwd '/tmp/habitat-plans'
+  environment HAB_ORIGIN: origin
+  live_stream true
+end
+
+execute "Install #{origin}/#{plan}" do
+  command lazy {
+    file = File.read('/tmp/habitat-plans/results/last_build.env')
+           .match(/^pkg_artifact=(.*)$/)[1]
+    "hab pkg install /tmp/habitat-plans/results/#{file}"
+  }
+  live_stream true
+end

--- a/test/full.sh
+++ b/test/full.sh
@@ -2,27 +2,6 @@
 
 set -eu
 
-install_habitat() {
-  # Ensure Habitat is installed.
-  if ! command -v hab > /dev/null; then
-    echo "[INFO] Habitat not found; installing..."
-    if command -v brew > /dev/null; then
-      echo -n "    [INFO] Installing Habitat via Homebrew..."
-      brew tap habitat-sh/habitat > /dev/null
-      brew install hab > /dev/null && echo " OK"
-    else
-      echo -n "    [INFO] Installing Habitat via curl..."
-      # The gpg key import in Hab's install script sends some stuff to stderr.
-      curl -s https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash > /dev/null 2>&1 && echo " OK"
-    fi
-  fi
-
-  if ! hab origin key export "$HAB_ORIGIN" > /dev/null 2>&1; then
-    echo -n "[INFO] Generating a test Habitat signging key for origin $HAB_ORIGIN..."
-    hab origin key generate "$HAB_ORIGIN" > /dev/null && echo " OK"
-  fi
-}
-
 install_chefdk() {
   # Ensure Chef-DK is installed.
   if ! command -v chef > /dev/null; then
@@ -36,17 +15,12 @@ install_chefdk() {
       curl -s https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current -P chefdk > /dev/null
     fi
   fi
-  chef exec bundle install > /dev/null
 }
 
 run_kitchen () {
   plan="$1"
 
-  install_habitat
   install_chefdk
-
-  echo "[INFO] Building a test artifact for ${plan}..."
-  hab studio build "$plan"
 
   echo "[INFO] Running Test Kitchen for ${plan}..."
   chef exec kitchen test -d always


### PR DESCRIPTION
There's no way in kitchen-habitat to run multiple services in one supervisor
and we have plans like graphite-web that require access to files from other
services.