### PR TITLE
[inspec] Set the INSPEC_CONFIG_DIR environment variable

### DIFF
--- a/inspec/plan.sh
+++ b/inspec/plan.sh
@@ -44,6 +44,7 @@ export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
 set -e
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
+export INSPEC_CONFIG_DIR="$pkg_svc_data_path"
 exec $(pkg_path_for core/ruby)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"

--- a/inspec/test/fixtures/cookbooks/plan_test/metadata.rb
+++ b/inspec/test/fixtures/cookbooks/plan_test/metadata.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+name 'plan_test'
+maintainer 'Tyler Technologies, Data & Insights Division'
+maintainer_email 'sysadmin@socrata.com'
+license 'Apache-2.0'
+description 'Test wrapper'
+long_description 'Test wrapper'
+version '0.0.1'
+
+depends 'hab_test'

--- a/inspec/test/fixtures/cookbooks/plan_test/recipes/default.rb
+++ b/inspec/test/fixtures/cookbooks/plan_test/recipes/default.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+include_recipe 'hab_test'


### PR DESCRIPTION
The default is the hab user's home directory which may not exist and, even if
it does, a Habitat app shouldn't be trying to write to.

Despite being named "config", it's more of a data directory, with cache data
and such.