### PR TITLE
[inspec] Revert the addition of INSPEC_CONFIG_DIR

### DIFF
--- a/inspec/plan.sh
+++ b/inspec/plan.sh
@@ -44,7 +44,6 @@ export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
 set -e
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
-export INSPEC_CONFIG_DIR="$pkg_svc_data_path"
 exec $(pkg_path_for core/ruby)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"


### PR DESCRIPTION
There were two issues with this:

- Inspec itself doesn't run as a service so the directory doesn't exist. The
  path should be set by the service using Inspec to somewhere it has access to.
- The v1 plugins don't acknowledge this var and just use `Dir.home`.

Looks like the solution is for the services using this package to set HOME as
part of their health check script.